### PR TITLE
add tc_log_debugN function and configure's option —— '--enable-debug'

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@
 AC_PREREQ(2.59)
 AC_INIT(tcpcopy, 0.5.0, wangbin579@gmail.com)
 AC_CONFIG_SRCDIR([src/interception/main.c])
-AC_CONFIG_HEADER([config.h])
+AC_CONFIG_HEADER([src/core/config.h])
 
 
 AM_INIT_AUTOMAKE(tcpcopy,0.5.0)
@@ -21,7 +21,7 @@ AM_PROG_LIBTOOL
 
 AC_ARG_ENABLE(debug, AS_HELP_STRING([--enable-debug],[compile with debug support]),,enable_debug=no)
 if test "x$enable_debug" = "xyes";then
-	AC_DEFINE(TC_DEBUG, 1, [Define if we're using X Session Management.])
+	AC_DEFINE(TCPCOPY_DEBUG, 1, [Define if --enable-debug])
 fi
 
 # Checks for header files.

--- a/src/core/xcopy.h
+++ b/src/core/xcopy.h
@@ -257,7 +257,5 @@ void strace_pack(int level, int flag, struct iphdr *ip_header,
         struct tcphdr *tcp_header);
 int daemonize();
 
-void log_info(int level, const char *fmt, ...);
-
 #endif   /* ----- #ifndef _XCOPY_H_INC ----- */
 

--- a/src/log/log.h
+++ b/src/log/log.h
@@ -1,8 +1,52 @@
 #ifndef  _LOG_H_INC
 #define  _LOG_H_INC
 
-    void log_init();
-    void log_end();
+#include "config.h"
 
-#endif  
+void log_init();
+void log_end();
+
+void log_info(int level, const char *fmt, ...);
+
+#if (TCPCOPY_DEBUG)
+
+#define tc_log_debug0(level, fmt)                                       \
+    log_info(level, (const char *) fmt)
+
+#define tc_log_debug1(level, fmt, a1)                                   \
+    log_info(level, (const char *) fmt, a1)
+
+#define tc_log_debug2(level, fmt, a1, a2)                               \
+    log_info(level, (const char *) fmt, a1, a2)
+
+#define tc_log_debug3(level, fmt, a1, a2, a3)                           \
+    log_info(level, (const char *) fmt, a1, a2, a3)
+
+#define tc_log_debug4(level, fmt, a1, a2, a3, a4)                       \
+    log_info(level, (const char *) fmt, a1, a2, a3, a4)
+
+#define tc_log_debug5(level, fmt, a1, a2, a3, a4, a5)                   \
+    log_info(level, (const char *) fmt, a1, a2, a3, a4, a5)
+
+#define tc_log_debug6(level, fmt, a1, a2, a3, a4, a5, a6)               \
+    log_info(level, (const char *) fmt, a1, a2, a3, a4, a5, a6)
+
+#define tc_log_debug7(level, fmt, a1, a2, a3, a4, a5, a6, a7)           \
+    log_info(level, (const char *) fmt, a1, a2, a3, a4, a5, a6, a7)
+
+#else
+
+#define tc_log_debug0(level, fmt)
+#define tc_log_debug1(level, fmt, a1)
+#define tc_log_debug2(level, fmt, a1, a2)
+#define tc_log_debug3(level, fmt, a1, a2, a3)
+#define tc_log_debug4(level, fmt, a1, a2, a3, a4)
+#define tc_log_debug5(level, fmt, a1, a2, a3, a4, a5)
+#define tc_log_debug6(level, fmt, a1, a2, a3, a4, a5, a6)
+#define tc_log_debug7(level, fmt, a1, a2, a3, a4, a5, a6, a7)
+
+#endif /* TCPCOPY_DEBUG */
+
+#endif /* _LOG_H_INC */
+
 

--- a/src/tcpcopy/manager.c
+++ b/src/tcpcopy/manager.c
@@ -78,16 +78,15 @@ static int replicate_packs(char *packet, int length, int replica_num)
     tcp_header = (struct tcphdr*)((char *)ip_header + size_ip);
     orig_port  = ntohs(tcp_header->source);
 
-#if (DEBUG_TCPCOPY)
-    log_info(LOG_DEBUG, "orig port:%u", orig_port);
-#endif
+    tc_log_debug1(LOG_DEBUG, "orig port:%u", orig_port);
+
     rand_port = clt_settings.rand_port_shifted;
     for(i = 1; i < replica_num; i++){
         addition   = (((i << 1)-1) << 5) + rand_port;
         dest_port  = get_appropriate_port(orig_port, addition);
-#if (DEBUG_TCPCOPY)
-        log_info(LOG_DEBUG, "new port:%u,add:%u", dest_port, addition);
-#endif
+
+        tc_log_debug2(LOG_DEBUG, "new port:%u,add:%u", dest_port, addition);
+
         tcp_header->source = htons(dest_port);
         process_packet(true, packet, length);
     }


### PR DESCRIPTION
1、添加一组debug日志的宏，主要是为了避免在代码中大量出现如下冗余代码： 
# if (DEBUG_TCPCOPY)

 。。。。。
# endif

2、使用方法可以参考此patch在manager.c中的两处修改。

注意：开启debug需要在configure的时候使用--enable-debug选项， configure --enable-debug
