### PR TITLE
add check for getopt.h and improve illegal option help tips

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -92,7 +92,7 @@ fi
 
 # Checks for header files.
 AC_HEADER_STDC
-AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h netinet/in.h stdint.h stdlib.h string.h sys/file.h sys/param.h sys/socket.h sys/time.h unistd.h])
+AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h netinet/in.h stdint.h stdlib.h string.h sys/file.h sys/param.h sys/socket.h sys/time.h unistd.h getopt.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_HEADER_STDBOOL

--- a/src/interception/main.c
+++ b/src/interception/main.c
@@ -151,6 +151,7 @@ static int
 read_args(int argc, char **argv) {
     int  c;
 
+    opterr = 0;
     while (-1 != (c = getopt(argc, argv,
          "x:" /* ip list passed through ip firewall */
          "p:" /* TCP port number to listen on */
@@ -195,8 +196,33 @@ read_args(int argc, char **argv) {
             case 'd':
                 srv_settings.do_daemonize = 1;
                 break;
+            case '?':
+                switch (optopt) {    
+                    case 'x':
+                        fprintf(stderr, "TCPCopy: option -%c require a ip address list\n", optopt);
+                        break;
+                    case 'b':
+                        fprintf(stderr, "TCPCopy: option -%c require a ip address\n", optopt);
+                        break;
+                    case 'l':
+                    case 'P':
+                        fprintf(stderr, "TCPCopy: option -%c require a file name\n", optopt);
+                        break;
+
+                    case 'p':
+                    case 't':
+                    case 's':
+                        fprintf(stderr, "TCPCopy: option -%c require a number\n", optopt);
+                        break;
+
+                    default:
+                        fprintf(stderr, "TCPCopy: illegal argument \"%c\"\n", optopt);
+                        break;
+                }
+                return -1;
+
             default:
-                fprintf(stderr, "Illegal argument \"%c\"\n", c);
+                fprintf(stderr, "TCPCopy: illegal argument \"%c\"\n", optopt);
                 return -1;
         }
 

--- a/src/tcpcopy/main.c
+++ b/src/tcpcopy/main.c
@@ -123,6 +123,7 @@ read_args(int argc, char **argv)
 {
     int  c;
 
+    opterr = 0;
     while (-1 != (c = getopt(argc, argv,
          "x:" /* <transfer,> */
          "c:" /* the localhost client ip will be changed to this ip address */
@@ -218,8 +219,54 @@ read_args(int argc, char **argv)
             case 'r':
                 clt_settings.percentage = atoi(optarg);
                 break;
+            case '?':
+                switch (optopt) {    
+                    case 'x':
+#if (TCPCOPY_MYSQL_ADVANCED)
+                    case 'u':
+#endif
+                        fprintf(stderr, "TCPCopy: option -%c require a string\n", optopt);
+                        break;
+                    case 'c':
+                        fprintf(stderr, "TCPCopy: option -%c require a ip address\n", optopt);
+                        break;
+#if (TCPCOPY_OFFLINE)
+                    case 'i':
+#endif
+                    case 'l':
+                    case 'P':
+                        fprintf(stderr, "TCPCopy: option -%c require a file name\n", optopt);
+                        break;
+#if (TCPCOPY_PCAP)
+                    case 'i':
+                        fprintf(stderr, "TCPCopy: option -%c require a device name\n", optopt);
+                        break;
+#endif
+#if (TCPCOPY_DR)
+                    case 's':
+                        fprintf(stderr, "TCPCopy: option -%c require a ip address list\n", optopt);
+                        break;
+#endif
+
+                    case 'n':
+                    case 'f':
+                    case 'm':
+                    case 'M':
+                    case 'S':
+                    case 't':
+                    case 'p':
+                    case 'r':
+                        fprintf(stderr, "TCPCopy: option -%c require a number\n", optopt);
+                        break;
+
+                    default:
+                        fprintf(stderr, "TCPCopy: illegal argument \"%c\"\n", optopt);
+                        break;
+                }
+                return -1;
+
             default:
-                fprintf(stderr, "Illegal argument \"%c\"\n", c);
+                fprintf(stderr, "TCPCopy: illegal argument \"%c\"\n", optopt);
                 return -1;
         }
     }


### PR DESCRIPTION
1) 添加了对getopt.h头文件的检查。
2) 将opterr设置为0，可以去除getopt遇见非法argument输出类似的信息
    ./tcpcopy: invalid option -- 'o'
3) getopt遇到无法解析或需要参数没有参数的option，会返回'?'，非法option会保存在‘optopt’中，所以针对返回'?'，可以对相应非法option给出合理的提示。
