### PR TITLE
使用sigaction替代signal

### DIFF
--- a/src/core/xcopy.h
+++ b/src/core/xcopy.h
@@ -271,5 +271,12 @@ inline int before(uint32_t seq1, uint32_t seq2);
 #include <tc_socket.h>
 
 
+struct signal {
+    int  signo;
+    char *signame;
+    int  flags;
+    void (*handler)(int signo);
+};
+
 #endif /* XCOPY_H_INCLUDED */
 

--- a/src/interception/main.c
+++ b/src/interception/main.c
@@ -58,12 +58,37 @@ signal_handler(int sig)
     s_event_loop.event_over = 1;
 }
 
-static void
+static struct signal signals[] = {
+    { SIGALRM, "SIGALRM", 0,    tc_time_sig_alarm },
+    { SIGTERM, "SIGTERM", 0,    signal_handler },
+    { SIGINT,  "SIGINT",  0,    signal_handler },
+    { SIGPIPE, "SIGPIPE", 0,    SIG_IGN },
+    { 0,        NULL,     0,    NULL }
+};
+
+static int
 set_signal_handler()
 {
-    signal(SIGALRM, tc_time_sig_alarm);
-    signal(SIGTERM, signal_handler);
-    signal(SIGINT, signal_handler);
+    struct signal *sig;
+
+    for (sig = signals; sig->signo != 0; sig++) {
+        int status;
+        struct sigaction sa;
+
+        memset(&sa, 0, sizeof(sa));
+        sa.sa_handler = sig->handler;
+        sa.sa_flags = sig->flags;
+        sigemptyset(&sa.sa_mask);
+
+        status = sigaction(sig->signo, &sa, NULL);
+        if (status < 0) {
+            tc_log_info(LOG_ERR, 0, "sigaction(%s) failed: %s", sig->signame,
+                      strerror(errno));
+            return -1;
+        }
+    }
+
+    return 0;
 }
 
 /* retrieve ip addresses */
@@ -222,12 +247,6 @@ read_args(int argc, char **argv) {
 static int  
 set_details()
 {
-    /* ignore SIGPIPE signals */
-    if (sigignore(SIGPIPE) == -1) {
-        tc_log_info(LOG_ERR, errno, "failed to ignore SIGPIPE");
-        return -1;
-    }
-
     /* retrieve ip address */
     if (srv_settings.raw_ip_list != NULL) {
         tc_log_info(LOG_NOTICE, 0, "-x parameter:%s", 
@@ -263,8 +282,6 @@ static void settings_init(void)
     srv_settings.port = SERVER_PORT;
     srv_settings.hash_size = 65536;
     srv_settings.binded_ip = NULL;
-
-    set_signal_handler();
 }
 
 static void output_for_debug()
@@ -297,6 +314,10 @@ main(int argc, char **argv)
     int ret;
 
     settings_init();
+
+    if (set_signal_handler() == -1) {
+        return -1;
+    }
 
     tc_time_init();
 

--- a/src/tcpcopy/main.c
+++ b/src/tcpcopy/main.c
@@ -20,14 +20,38 @@ xcopy_clt_settings clt_settings;
 int tc_raw_socket_out;
 tc_event_loop_t event_loop;
 
-static void
+static struct signal signals[] = {
+    { SIGALRM, "SIGALRM", 0,    tc_time_sig_alarm },
+    { SIGINT,  "SIGINT",  0,    tcp_copy_over },
+    { SIGPIPE, "SIGPIPE", 0,    tcp_copy_over },
+    { SIGHUP,  "SIGHUP",  0,    tcp_copy_over },
+    { SIGTERM, "SIGTERM", 0,    tcp_copy_over },
+    { 0,        NULL,     0,    NULL }
+};
+
+static int
 set_signal_handler()
 {
-    signal(SIGALRM, tc_time_sig_alarm);
-    signal(SIGINT,  tcp_copy_over);
-    signal(SIGPIPE, tcp_copy_over);
-    signal(SIGHUP,  tcp_copy_over);
-    signal(SIGTERM, tcp_copy_over);
+    struct signal *sig;
+
+    for (sig = signals; sig->signo != 0; sig++) {
+        int status;
+        struct sigaction sa;
+
+        memset(&sa, 0, sizeof(sa));
+        sa.sa_handler = sig->handler;
+        sa.sa_flags = sig->flags;
+        sigemptyset(&sa.sa_mask);
+
+        status = sigaction(sig->signo, &sa, NULL);
+        if (status < 0) {
+            tc_log_info(LOG_ERR, 0, "sigaction(%s) failed: %s", sig->signame,
+                      strerror(errno));
+            return -1;
+        }
+    }
+
+    return 0;
 }
 
 static void
@@ -630,8 +654,6 @@ settings_init()
     clt_settings.session_timeout = DEFAULT_SESSION_TIMEOUT;
 
     tc_raw_socket_out = TC_INVALID_SOCKET;
-
-    set_signal_handler();
 }
 
 /*
@@ -643,6 +665,10 @@ main(int argc, char **argv)
     int ret;
 
     settings_init();
+
+    if (set_signal_handler() == -1) {
+        return -1;
+    }
 
     tc_time_init();
 


### PR DESCRIPTION
unix环境高级编程中有关于说signal可能会丢失信号，或者使用signal注册的信号处理函数会在执行一次后恢复默认行为，推荐使用sigaction。如果采用sigaction的话，可以将signal结构体定义、set_signal_handler()及sigignore()函数放到专门的处理信号的一个文件或者tc_util文件中，使得模块化。
