### PR TITLE
Fix a small memory leak.

### DIFF
--- a/src/communication/tc_socket.c
+++ b/src/communication/tc_socket.c
@@ -122,6 +122,9 @@ tc_pcap_socket_in_init(pcap_t **pd, char *device,
         return TC_INVALID_SOCKET;
     }
 
+     /* free the memory used for the compiled filter */
+     pcap_freecode (&fp);
+
     if (pcap_get_selectable_fd(*pd) == -1) {
         tc_log_info(LOG_ERR, 0, "pcap_get_selectable_fd fails"); 
         return TC_INVALID_SOCKET;


### PR DESCRIPTION
cap_freecode() should be called to free up allocated memory pointed to by a bpf_program struct generated by pcap_compile() when that BPF program is no longer needed.
