### PR TITLE
Fix a small memory leak.

### DIFF
--- a/src/communication/tc_socket.c
+++ b/src/communication/tc_socket.c
@@ -119,8 +119,12 @@ tc_pcap_socket_in_init(pcap_t **pd, char *device,
     if (pcap_setfilter(*pd, &fp) == -1) {
         tc_log_info(LOG_ERR, 0, "couldn't install filter %s: %s",
                 pcap_filter, pcap_geterr(*pd));
+        pcap_freecode (&fp);
         return TC_INVALID_SOCKET;
     }
+
+     /* free the memory used for the compiled filter */
+     pcap_freecode (&fp);
 
     if (pcap_get_selectable_fd(*pd) == -1) {
         tc_log_info(LOG_ERR, 0, "pcap_get_selectable_fd fails"); 


### PR DESCRIPTION
pcap_freecode() should be called to free up allocated memory pointed to by a bpf_program struct generated by pcap_compile() when that BPF program is no longer needed.
