### PR TITLE
修复定时器回调函数为空引起core的问题

### DIFF
--- a/src/event/tc_event.c
+++ b/src/event/tc_event.c
@@ -256,7 +256,6 @@ static void tc_event_timer_run(tc_event_loop_t *loop)
 
     for (timer = loop->timers; timer; ) {
         if (timer->msec <= tc_current_time_msec && timer->handler) {
-            timer->handler(timer);
 
             if (timer->handler == NULL) {
                 if (prev) {
@@ -271,6 +270,8 @@ static void tc_event_timer_run(tc_event_loop_t *loop)
 
                 continue;
             }
+
+            timer->handler(timer);
         }
 
         prev = timer;


### PR DESCRIPTION
在定时器tc_event_timer_run函数中，如果添加的定时器回调函数为NULL，会引起core。
