### PR TITLE
fix a small out of bounds bug

### DIFF
--- a/src/event/tc_event.c
+++ b/src/event/tc_event.c
@@ -293,6 +293,7 @@ static void tc_event_timer_run(tc_event_loop_t *loop)
     for (timer = loop->timers; timer; ) {
         if (timer->msec <= tc_current_time_msec && timer->handler) {
             timer->handler(timer);
+
             if (timer->handler == NULL) {
                 if (prev) {
                     prev->next = timer->next;


### PR DESCRIPTION
在启用TCPCOPY_PCAP模式下，devices的个数超过MAX_DEVICE_NUM会引起越界问题。
