### PR TITLE
Fix issue #213: if the length of IP packet is greater than MTU, the payload of TCP segment is incorrect

### DIFF
--- a/src/tcpcopy/tc_packets_module.c
+++ b/src/tcpcopy/tc_packets_module.c
@@ -405,11 +405,10 @@ dispose_packet(unsigned char *packet, int ip_rcv_len, int *p_valid_flag)
                 p = (char *) pack_buffer2;
                 /* copy header here */
                 memcpy(p, (char *) packet, head_len);
-                p +=  head_len;
                 /* copy payload here */
-                memcpy(p, (char *) (packet + index), payload_len);
+                memcpy(p + head_len, (char *) (packet + index), payload_len);
                 index = index + payload_len;
-                packet_valid = tc_proc_ingress(ip, tcp);
+                packet_valid = tc_proc_ingress(p, tcp);
                 if (replica_num > 1) {
                     replicate_packs(ip, tcp, replica_num);
                 }


### PR DESCRIPTION
if the length of IP packet is greater than MTU, the payload of TCP segment is incorrect